### PR TITLE
Make `from zschema import *` great again.

### DIFF
--- a/zschema/__init__.py
+++ b/zschema/__init__.py
@@ -4,4 +4,7 @@ __copyright__ = "Copyright 2015 Regents of the Unversity of Michigan"
 __version__ = "0.0.27"
 __license__ = "Apache License, Version 2.0"
 
-__all__ = ["keys", "leaves", "compounds", "registry"]
+from keys import *
+from leaves import *
+from compounds import *
+from registry import *


### PR DESCRIPTION
Do not merge yet.

This fixes the issue where `from zschema import *` was not importing all
relevant names (e.g. SubRecord). However, zschema validate is currently
not working because the zschema.registry module seems to be loaded
twice, and then the lookup for the relevent schema in `__schemas`
NameError's. I do not understand why this is happening, or how to fix.
Even reverting to the old code in `__init__.py` results in the same
double-initialize behavior.