### PR TITLE
Add zschema.registry.all_schemas

### DIFF
--- a/zschema/registry.py
+++ b/zschema/registry.py
@@ -10,3 +10,7 @@ def register_schema(name, schema):
 def get_schema(name):
     global __zschema_schemas
     return __zschema_schemas[name]
+
+def all_schemas():
+    global __zschema_schemas
+    return __zschema_schemas.copy()

--- a/zschema/tests.py
+++ b/zschema/tests.py
@@ -1,6 +1,7 @@
 import json
 import pprint
 
+from zschema import registry
 from zschema.leaves import *
 from zschema.compounds import *
 
@@ -301,3 +302,44 @@ class CompileAndValidationTests(unittest.TestCase):
         }
         self.host.validate(test)
 
+
+class RegistryTests(unittest.TestCase):
+
+    def setUp(self):
+        self.host = Record({
+                "ipstr":IPv4Address(required=True),
+                "ip":Unsigned32BitInteger(),
+        })
+        self.domain = Record({
+                "domain":String(required=True),
+        })
+
+    def test_get_registered(self):
+        try:
+            registry.get_schema("host")
+            self.fail("missing schema should throw")
+        except KeyError:
+            pass
+        all_schemas = registry.all_schemas()
+        self.assertEqual(0, len(all_schemas))
+
+        registry.register_schema("host", self.host)
+        try:
+            host_schema = registry.get_schema("host")
+        except KeyError:
+            self.fail("registered schema should not throw")
+        all_schemas = registry.all_schemas()
+        self.assertEqual(1, len(all_schemas))
+        all_schemas['domain'] = self.domain
+
+        all_schemas = registry.all_schemas()
+        self.assertEqual(1, len(all_schemas))
+
+        registry.register_schema("domain", self.domain)
+        self.assertEqual(1, len(all_schemas))
+        try:
+            domain_schema = registry.get_schema("domain")
+        except KeyError:
+            self.fail("registered schema should not throw")
+        all_schemas = registry.all_schemas()
+        self.assertEqual(2, len(all_schemas))


### PR DESCRIPTION
This function returns all schemas defined in the registry. It returns a
shallow copy of the internal __zschema_schemas object, so that adding
items to the returned dict does not modify the internal registry.

This function can be used to genenerate all the schemas in a file
programmatically, and may be useful in CI scripts.