### PR TITLE
Allow validating ipv4 results with port dicts at the top level

### DIFF
--- a/zschema/compounds.py
+++ b/zschema/compounds.py
@@ -192,8 +192,11 @@ class Record(SubRecord):
             raise DataValidationException("record is not a dict", str(value))
         for subkey, subvalue in value.items():
             if subkey not in self.definition:
-                raise DataValidationException("%s is not a valid subkey of root",
-                                              subkey)
+                port = Port(subkey)
+                if port not in self.definition:
+                    raise DataValidationException("%s is not a valid subkey of root",
+                                                  subkey)
+                subkey = port
             self.definition[subkey].validate(subkey, subvalue)
 
     def to_dict(self):
@@ -210,5 +213,3 @@ class Record(SubRecord):
     @classmethod
     def from_json(cls, j):
         return cls({(k, __encode(v)) for k, v in j.items()})
-
-

--- a/zschema/keys.py
+++ b/zschema/keys.py
@@ -13,7 +13,7 @@ class Port(object):
     def __eq__(self, other):
         if type(other) == int:
             return int(self.port).__eq__(other)
-        elif type(other) == str:
+        elif type(other) in {str, unicode}:
             return self.port.__eq__(other)
         else:
             return self.port.__eq__(other.port)


### PR DESCRIPTION
This fixes a couple issues I ran into while trying to validate my changes in https://github.com/zmap/ztag/pull/68: first ZSchema wasn't able to compare the top-level key (due to the unfortunate way Unicode is handled), then the validator didn't seem to be able to handle a port being used as a key at all.

@dadrian helped with these changes.