### PR TITLE
Add JSON schema descriptions for BQ and ES

### DIFF
--- a/zschema/__main__.py
+++ b/zschema/__main__.py
@@ -28,10 +28,10 @@ def main():
         print json.dumps(record.to_bigquery())
     elif command == "elasticsearch":
         print json.dumps(record.to_es(recname))
-    elif command == "bq-annotated":
-        print json.dumps(record.to_bigquery(annotated=True))
     elif command == "docs-es":
         print json.dumps(record.docs_es(recname))
+    elif command == "docs-bq":
+        print json.dumps(record.docs_bq(recname))
     elif command == "json":
         print record.to_json()
     elif command == "flat":

--- a/zschema/__main__.py
+++ b/zschema/__main__.py
@@ -11,7 +11,7 @@ from compounds import *
 
 def usage():
     sys.stderr.write("USAGE: %s command schema [file].\n" % sys.argv[0].split("/")[-1])
-    sys.stderr.write("Valid commands: bigquery, elasticsearch, es-annotated, json, flat, validate.\n")
+    sys.stderr.write("Valid commands: bigquery, elasticsearch, es-annotated, bq-annotated, json, flat, validate.\n")
     sys.stderr.write("Schema should be passed as file.py:record\n")
     sys.stderr.write("The optional 'file' argument is used only as the test file for the 'validate' command.\n")
     sys.stderr.write("VERSION: %s\n" % zschema.__version__)
@@ -30,6 +30,8 @@ def main():
         print json.dumps(record.to_es(recname))
     elif command == "es-annotated":
         print json.dumps(record.to_es(recname, annotated=True))
+    elif command == "bq-annotated":
+        print json.dumps(record.to_bigquery(annotated=True))
     elif command == "json":
         print record.to_json()
     elif command == "flat":

--- a/zschema/__main__.py
+++ b/zschema/__main__.py
@@ -13,6 +13,7 @@ def usage():
     sys.stderr.write("USAGE: %s command schema [file].\n" % sys.argv[0].split("/")[-1])
     sys.stderr.write("Valid commands: bigquery, elasticsearch, json, text, flat, validate.\n")
     sys.stderr.write("Schema should be passed as file.py:record\n")
+    sys.stderr.write("The optional 'file' argument is used only as the test file for the 'validate' command.\n")
     sys.stderr.write("VERSION: %s\n" % zschema.__version__)
     sys.exit(1)
 

--- a/zschema/__main__.py
+++ b/zschema/__main__.py
@@ -11,7 +11,7 @@ from compounds import *
 
 def usage():
     sys.stderr.write("USAGE: %s command schema [file].\n" % sys.argv[0].split("/")[-1])
-    sys.stderr.write("Valid commands: bigquery, elasticsearch, es-annotated, json, text, flat, validate.\n")
+    sys.stderr.write("Valid commands: bigquery, elasticsearch, es-annotated, json, flat, validate.\n")
     sys.stderr.write("Schema should be passed as file.py:record\n")
     sys.stderr.write("The optional 'file' argument is used only as the test file for the 'validate' command.\n")
     sys.stderr.write("VERSION: %s\n" % zschema.__version__)
@@ -32,8 +32,6 @@ def main():
         print json.dumps(record.to_es(recname, annotated=True))
     elif command == "json":
         print record.to_json()
-    elif command == "text":
-        print record.to_text()
     elif command == "flat":
         for r in record.to_flat():
             print json.dumps(r)

--- a/zschema/__main__.py
+++ b/zschema/__main__.py
@@ -11,7 +11,7 @@ from compounds import *
 
 def usage():
     sys.stderr.write("USAGE: %s command schema [file].\n" % sys.argv[0].split("/")[-1])
-    sys.stderr.write("Valid commands: bigquery, elasticsearch, json, text, flat, validate.\n")
+    sys.stderr.write("Valid commands: bigquery, elasticsearch, es-annotated, json, text, flat, validate.\n")
     sys.stderr.write("Schema should be passed as file.py:record\n")
     sys.stderr.write("The optional 'file' argument is used only as the test file for the 'validate' command.\n")
     sys.stderr.write("VERSION: %s\n" % zschema.__version__)
@@ -28,6 +28,8 @@ def main():
         print json.dumps(record.to_bigquery())
     elif command == "elasticsearch":
         print json.dumps(record.to_es(recname))
+    elif command == "es-annotated":
+        print json.dumps(record.to_es(recname, annotated=True))
     elif command == "json":
         print record.to_json()
     elif command == "text":

--- a/zschema/__main__.py
+++ b/zschema/__main__.py
@@ -11,7 +11,7 @@ from compounds import *
 
 def usage():
     sys.stderr.write("USAGE: %s command schema [file].\n" % sys.argv[0].split("/")[-1])
-    sys.stderr.write("Valid commands: bigquery, elasticsearch, es-annotated, bq-annotated, json, flat, validate.\n")
+    sys.stderr.write("Valid commands: bigquery, elasticsearch, docs-es, docs-bq, json, flat, validate.\n")
     sys.stderr.write("Schema should be passed as file.py:record\n")
     sys.stderr.write("The optional 'file' argument is used only as the test file for the 'validate' command.\n")
     sys.stderr.write("VERSION: %s\n" % zschema.__version__)
@@ -28,10 +28,10 @@ def main():
         print json.dumps(record.to_bigquery())
     elif command == "elasticsearch":
         print json.dumps(record.to_es(recname))
-    elif command == "es-annotated":
-        print json.dumps(record.to_es(recname, annotated=True))
     elif command == "bq-annotated":
         print json.dumps(record.to_bigquery(annotated=True))
+    elif command == "docs-es":
+        print json.dumps(record.docs_es(recname))
     elif command == "json":
         print record.to_json()
     elif command == "flat":

--- a/zschema/__main__.py
+++ b/zschema/__main__.py
@@ -11,8 +11,8 @@ from compounds import *
 
 def usage():
     sys.stderr.write("USAGE: %s command schema [file].\n" % sys.argv[0].split("/")[-1])
-    sys.stderr.write("Valid commands: bigquery, elasticsearch, json, text, html, censys-html, flat, validate.\n")
-    sys.stderr.write("schema should be defined as file.py:record\n")
+    sys.stderr.write("Valid commands: bigquery, elasticsearch, json, text, flat, validate.\n")
+    sys.stderr.write("Schema should be passed as file.py:record\n")
     sys.stderr.write("VERSION: %s\n" % zschema.__version__)
     sys.exit(1)
 
@@ -29,24 +29,11 @@ def main():
         print json.dumps(record.to_es(recname))
     elif command == "json":
         print record.to_json()
-    elif command == "html":
-        for r in record.to_flat():
-            type_ = r.get("es_type", "")
-            print "<tr><td>%s</td><td>%s</td></tr>" % (r["name"], type_)
     elif command == "text":
         print record.to_text()
     elif command == "flat":
         for r in record.to_flat():
             print json.dumps(r)
-    elif command == "censys-html":
-        for r in record.to_flat():
-            type_ = r.get("es_type", None)
-            len_ = r["name"].count(".")
-            style = 'style="padding-left: %ipx"' % (15 * len_ + 5)
-            if not type_:
-                print '<tr class="record"><td %s>%s</td><td>%s</td></tr>' % (style, r["name"], "")
-            else:
-                print "<tr><td %s>%s</td><td>%s</td></tr>" % (style, r["name"], type_)
     elif command == "validate":
         if not os.path.exists(sys.argv[3]):
             sys.stderr.write("Invalid test file. %s does not exist.\n" % sys.argv[3])

--- a/zschema/compounds.py
+++ b/zschema/compounds.py
@@ -175,18 +175,9 @@ class Record(SubRecord):
         return [s.to_bigquery(name) for (name, s) in source \
                 if not s.exclude_bigquery]
 
-    def to_html(self):
-        pass
-
-    def to_documented_html(self):
-        pass
-
     def print_indent_string(self):
         for name, field in sorted(self.definition.iteritems()):
             field.print_indent_string(name, 0)
-
-    def to_dotted_text(self):
-        pass
 
     def validate(self, value):
         if type(value) != dict:
@@ -212,5 +203,3 @@ class Record(SubRecord):
     @classmethod
     def from_json(cls, j):
         return cls({(k, __encode(v)) for k, v in sorted(j.iteritems())})
-
-

--- a/zschema/compounds.py
+++ b/zschema/compounds.py
@@ -10,10 +10,11 @@ def _is_valid_object(name, object_):
 
 class ListOf(Keyable):
 
-    def __init__(self, object_, max_items=10, category=None):
+    def __init__(self, object_, max_items=10, doc=None, category=None):
         self.object_ = object_
         self.max_items = max_items
         self.category = category
+        self.doc = doc
         _is_valid_object("Anonymous ListOf", object_)
 
     @property
@@ -39,6 +40,8 @@ class ListOf(Keyable):
         category = self.category or parent_category
         retv["category"] = category
         retv["repeated"] = True
+        if self.doc:
+            retv["doc"] = self.doc
         return retv
 
     def to_es(self):
@@ -48,6 +51,8 @@ class ListOf(Keyable):
         retv = self.object_.docs_es()
         category = self.category or parent_category
         retv["category"] = category
+        if self.doc:
+            retv["doc"] = self.doc
         return retv
 
     def validate(self, name, value):
@@ -197,8 +202,8 @@ class SubRecord(Keyable):
 
 class NestedListOf(ListOf):
 
-    def __init__(self, object_, subrecord_name, max_items=10, category=None):
-        ListOf.__init__(self, object_, max_items, category=category)
+    def __init__(self, object_, subrecord_name, max_items=10, doc=None, category=None):
+        ListOf.__init__(self, object_, max_items, doc=doc, category=category)
         self.subrecord_name = subrecord_name
 
     def to_bigquery(self, name):
@@ -207,6 +212,8 @@ class NestedListOf(ListOf):
         })
         retv = subr.to_bigquery(self.key_to_bq(name))
         retv["mode"] = "REPEATED"
+        if self.doc:
+            retv["doc"] = self.doc
         return retv
 
     def docs_bq(self, parent_category=None):
@@ -216,6 +223,8 @@ class NestedListOf(ListOf):
         category = self.category or parent_category
         retv = subr.docs_bq(parent_category=category)
         retv["repeated"] = True
+        if self.doc:
+            retv["doc"] = self.doc
         return retv
 
 

--- a/zschema/compounds.py
+++ b/zschema/compounds.py
@@ -51,6 +51,7 @@ class ListOf(Keyable):
         retv = self.object_.docs_es()
         category = self.category or parent_category
         retv["category"] = category
+        retv["repeated"] = True
         if self.doc:
             retv["doc"] = self.doc
         return retv

--- a/zschema/compounds.py
+++ b/zschema/compounds.py
@@ -36,7 +36,7 @@ class ListOf(Keyable):
 
     def docs_bq(self, parent_category=None):
         retv = self.object_.docs_bq()
-        category = self.category if self.category else parent_category
+        category = self.category or parent_category
         retv["category"] = category
         retv["repeated"] = True
         return retv
@@ -46,7 +46,7 @@ class ListOf(Keyable):
 
     def docs_es(self, parent_category=None):
         retv = self.object_.docs_es()
-        category = self.category if self.category else parent_category
+        category = self.category or parent_category
         retv["category"] = category
         return retv
 
@@ -162,7 +162,7 @@ class SubRecord(Keyable):
         return {"properties": p}
 
     def _docs_common(self, parent_category):
-        category = self.category if self.category else parent_category
+        category = self.category or parent_category
         retv = {
             "category": category,
             "doc": self.doc,
@@ -213,7 +213,7 @@ class NestedListOf(ListOf):
         subr = SubRecord({
             self.subrecord_name: ListOf(self.object_)
         })
-        category = self.category if self.category else parent_category
+        category = self.category or parent_category
         retv = subr.docs_bq(parent_category=category)
         retv["repeated"] = True
         return retv
@@ -225,7 +225,7 @@ class Record(SubRecord):
         return {name:SubRecord.to_es(self)}
 
     def docs_es(self, name, parent_category=None):
-        category = self.category if self.category else parent_category
+        category = self.category or parent_category
         return {name: SubRecord.docs_es(self, parent_category=category)}
 
     def to_bigquery(self):
@@ -236,7 +236,7 @@ class Record(SubRecord):
                 ]
 
     def docs_bq(self, name, parent_category=None):
-        category = self.category if self.category else parent_category
+        category = self.category or parent_category
         return {name: SubRecord.docs_bq(self, parent_category=category)}
 
     def print_indent_string(self):

--- a/zschema/compounds.py
+++ b/zschema/compounds.py
@@ -33,8 +33,8 @@ class ListOf(Keyable):
         retv["mode"] = "REPEATED"
         return retv
 
-    def to_es(self):
-        return self.object_.to_es()
+    def to_es(self, annotated=False):
+        return self.object_.to_es(annotated=annotated)
 
     def validate(self, name, value):
         if type(value) != list:
@@ -128,10 +128,14 @@ class SubRecord(Keyable):
         for name, value in sorted(self.definition.iteritems()):
             value.print_indent_string(name, indent+1)
 
-    def to_es(self):
-        p = {self.key_to_es(k): v.to_es() for k, v in sorted(self.definition.iteritems()) \
+    def to_es(self, annotated=False):
+        p = {self.key_to_es(k): v.to_es(annotated=annotated) \
+                for k, v in sorted(self.definition.iteritems()) \
                 if not v.exclude_elasticsearch}
-        return {"properties": p}
+        retv = {"properties": p}
+        if annotated and self.doc:
+            retv["doc"] = self.doc
+        return retv
 
     def to_dict(self):
         source = sorted(self.definition.iteritems())
@@ -167,8 +171,8 @@ class NestedListOf(ListOf):
 
 class Record(SubRecord):
 
-    def to_es(self, name):
-        return {name:SubRecord.to_es(self)}
+    def to_es(self, name, annotated=False):
+        return {name:SubRecord.to_es(self, annotated=annotated)}
 
     def to_bigquery(self):
         source = sorted(self.definition.iteritems())

--- a/zschema/leaves.py
+++ b/zschema/leaves.py
@@ -81,6 +81,9 @@ class Leaf(Keyable):
             if self.doc:
                 retv["doc"] = self.doc
             retv["detail_type"] = self.__class__.__name__
+            if hasattr(self, "values_s") and len(self.values_s):
+                # gotta clean this up but for now...
+                retv["values"] = list(self.values_s)
         return retv
 
     def to_bigquery(self, name, annotated=False):
@@ -92,6 +95,9 @@ class Leaf(Keyable):
             retv["doc"] = self.doc
         if annotated:
             retv["detail_type"] = self.__class__.__name__
+            if hasattr(self, "values_s") and len(self.values_s):
+                # gotta clean this up but for now...
+                retv["values"] = list(self.values_s)
         return retv
 
     def to_string(self, name):

--- a/zschema/leaves.py
+++ b/zschema/leaves.py
@@ -15,6 +15,7 @@ class Leaf(Keyable):
             es_index=None,
             es_analyzer=None,
             doc=None,
+            examples=None,
             es_include_raw=None,
             deprecated=False,
             ignore=False,
@@ -30,6 +31,7 @@ class Leaf(Keyable):
         self.es_index = es_index
         self.es_analyzer = es_analyzer
         self.doc = doc
+        self.examples = examples if examples else []
         if es_include_raw is not None:
             self.es_include_raw = es_include_raw
         else:
@@ -56,7 +58,8 @@ class Leaf(Keyable):
             "type":self.__class__.__name__,
             "es_type":self.ES_TYPE,
             "bq_type":self.BQ_TYPE,
-            "metadata":self.metadata
+            "metadata":self.metadata,
+            "examples": self.examples,
         }
         if self.units is not None:
             retv["units"] = self.units
@@ -84,6 +87,8 @@ class Leaf(Keyable):
             if hasattr(self, "values_s") and len(self.values_s):
                 # gotta clean this up but for now...
                 retv["values"] = list(self.values_s)
+            else:
+                retv["examples"] = self.examples
         return retv
 
     def to_bigquery(self, name, annotated=False):
@@ -98,6 +103,8 @@ class Leaf(Keyable):
             if hasattr(self, "values_s") and len(self.values_s):
                 # gotta clean this up but for now...
                 retv["values"] = list(self.values_s)
+            else:
+                retv["examples"] = self.examples
         return retv
 
     def to_string(self, name):

--- a/zschema/leaves.py
+++ b/zschema/leaves.py
@@ -66,7 +66,7 @@ class Leaf(Keyable):
                 "ES_SEARCH_ANALYZER")
         return retv
 
-    def to_es(self):
+    def to_es(self, annotated=False):
         retv = {"type":self.ES_TYPE}
         self.add_es_var(retv, "index", "es_index", "ES_INDEX")
         self.add_es_var(retv, "analyzer", "es_analyzer", "ES_ANALYZER")
@@ -77,6 +77,8 @@ class Leaf(Keyable):
             retv["fields"] = {
                     "raw":{"type":"keyword"}
             }
+        if annotated and self.doc:
+            retv["doc"] = self.doc
         return retv
 
     def to_bigquery(self, name):

--- a/zschema/leaves.py
+++ b/zschema/leaves.py
@@ -83,13 +83,15 @@ class Leaf(Keyable):
             retv["detail_type"] = self.__class__.__name__
         return retv
 
-    def to_bigquery(self, name):
+    def to_bigquery(self, name, annotated=False):
         if not self._check_valid_name(name):
             raise Exception("Invalid field name: %s" % name)
         mode = "REQUIRED" if self.required else "NULLABLE"
         retv = {"name":self.key_to_bq(name), "type":self.BQ_TYPE, "mode":mode}
         if self.doc:
             retv["doc"] = self.doc
+        if annotated:
+            retv["detail_type"] = self.__class__.__name__
         return retv
 
     def to_string(self, name):

--- a/zschema/leaves.py
+++ b/zschema/leaves.py
@@ -65,32 +65,35 @@ class Leaf(Keyable):
                 "ES_SEARCH_ANALYZER")
         return retv
 
-    def to_es(self, annotated=False, parent_category=None):
+    def to_es(self):
         retv = {"type":self.ES_TYPE}
         self.add_es_var(retv, "index", "es_index", "ES_INDEX")
         self.add_es_var(retv, "analyzer", "es_analyzer", "ES_ANALYZER")
         self.add_es_var(retv, "search_analyzer", "es_search_analyzer",
                 "ES_SEARCH_ANALYZER")
-
         if self.es_include_raw:
             retv["fields"] = {
                     "raw":{"type":"keyword"}
             }
-        if annotated:
-            retv["detail_type"] = self.__class__.__name__
-            category = self.category if self.category else parent_category
-            retv["category"] = category
-            if self.doc:
-                retv["doc"] = self.doc
-            if self.min_value:
-                retv["min_value"] = self.min_value
-            if self.max_value:
-                retv["max_value"] = self.max_value
-            if hasattr(self, "values_s") and len(self.values_s):
-                # gotta clean this up but for now...
-                retv["values"] = list(self.values_s)
-            else:
-                retv["examples"] = self.examples
+        return retv
+
+    def _docs_common(self, parent_category):
+        retv = {
+            "detail_type": self.__class__.__name__,
+            "category": self.category if self.category else parent_category,
+            "doc": self.doc,
+            "required": self.required,
+        }
+        if hasattr(self, "values_s") and len(self.values_s):
+            retv["values"] = list(self.values_s)
+        else:
+            retv["examples"] = self.examples
+        return retv
+
+    def docs_es(self, parent_category=None):
+        retv = self._docs_common(parent_category)
+        self.add_es_var(retv, "analyzer", "es_analyzer", "ES_ANALYZER")
+        retv["type"] = self.ES_TYPE
         return retv
 
     def to_bigquery(self, name, annotated=False, parent_category=None):

--- a/zschema/leaves.py
+++ b/zschema/leaves.py
@@ -96,26 +96,18 @@ class Leaf(Keyable):
         retv["type"] = self.ES_TYPE
         return retv
 
-    def to_bigquery(self, name, annotated=False, parent_category=None):
+    def docs_bq(self, parent_category=None):
+        retv = self._docs_common(parent_category)
+        retv["type"] = self.BQ_TYPE
+        return retv
+
+    def to_bigquery(self, name):
         if not self._check_valid_name(name):
             raise Exception("Invalid field name: %s" % name)
         mode = "REQUIRED" if self.required else "NULLABLE"
         retv = {"name":self.key_to_bq(name), "type":self.BQ_TYPE, "mode":mode}
         if self.doc:
             retv["doc"] = self.doc
-        if annotated:
-            retv["detail_type"] = self.__class__.__name__
-            category = self.category if self.category else parent_category
-            retv["category"] = category
-            if self.min_value:
-                retv["min_value"] = self.min_value
-            if self.max_value:
-                retv["max_value"] = self.max_value
-            if hasattr(self, "values_s") and len(self.values_s):
-                # gotta clean this up but for now...
-                retv["values"] = list(self.values_s)
-            else:
-                retv["examples"] = self.examples
         return retv
 
     def to_string(self, name):

--- a/zschema/leaves.py
+++ b/zschema/leaves.py
@@ -77,8 +77,10 @@ class Leaf(Keyable):
             retv["fields"] = {
                     "raw":{"type":"keyword"}
             }
-        if annotated and self.doc:
-            retv["doc"] = self.doc
+        if annotated:
+            if self.doc:
+                retv["doc"] = self.doc
+            retv["detail_type"] = self.__class__.__name__
         return retv
 
     def to_bigquery(self, name):

--- a/zschema/leaves.py
+++ b/zschema/leaves.py
@@ -137,9 +137,6 @@ class Leaf(Keyable):
                 "mode":mode
             }
 
-    def to_autocomplete(self, parent, name, repated=False):
-        pass
-
     def print_indent_string(self, name, indent):
         val = self.key_to_string(name)
         if indent:

--- a/zschema/leaves.py
+++ b/zschema/leaves.py
@@ -80,7 +80,7 @@ class Leaf(Keyable):
     def _docs_common(self, parent_category):
         retv = {
             "detail_type": self.__class__.__name__,
-            "category": self.category if self.category else parent_category,
+            "category": self.category or parent_category,
             "doc": self.doc,
             "required": self.required,
         }

--- a/zschema/tests.py
+++ b/zschema/tests.py
@@ -115,6 +115,7 @@ VALID_BIG_QUERY = [
     {
         "type": "INTEGER",
         "name": "ip",
+        "doc": "The IP Address of the host",
         "mode": "NULLABLE"
     },
 ]
@@ -154,16 +155,16 @@ class CompileAndValidationTests(unittest.TestCase):
 
         heartbleed = SubRecord({
             "heartbeat_support":Boolean(),
-            "heartbleed_vulnerable":Boolean(),
+            "heartbleed_vulnerable":Boolean(category="Vulnerabilities"),
             "timestamp":DateTime()
         })
         self.host = Record({
-                "ipstr":IPv4Address(required=True),
-                "ip":Long(),
+                "ipstr":IPv4Address(required=True, examples=["8.8.8.8"]),
+                "ip":Long(doc="The IP Address of the host"),
                 Port(443):SubRecord({
                     "tls":String(),
                     "heartbleed":heartbleed
-                }),
+                }, category="heartbleed"),
                 "tags":ListOf(String())
         })
 

--- a/zschema/tests.py
+++ b/zschema/tests.py
@@ -67,6 +67,178 @@ VALID_ELASTIC_SEARCH = {
     }
 }
 
+VALID_DOCS_OUTPUT_FOR_ES_FIELDS = {
+    "host": {
+        "category": None,
+        "doc": None,
+        "fields": {
+            "443": {
+                "category": "heartbleed",
+                "doc": None,
+                "fields": {
+                    "heartbleed": {
+                        "category": None,
+                        "doc": None,
+                        "fields": {
+                            "heartbeat_support": {
+                                "category": None,
+                                "detail_type": "Boolean",
+                                "doc": None,
+                                "examples": [],
+                                "required": False,
+                                "type": "boolean"
+                            },
+                            "heartbleed_vulnerable": {
+                                "category": "Vulnerabilities",
+                                "detail_type": "Boolean",
+                                "doc": None,
+                                "examples": [],
+                                "required": False,
+                                "type": "boolean"
+                            },
+                            "timestamp": {
+                                "category": None,
+                                "detail_type": "DateTime",
+                                "doc": None,
+                                "examples": [],
+                                "required": False,
+                                "type": "date"
+                            }
+                        },
+                        "required": False,
+                        "type": "SubRecord"
+                    },
+                    "tls": {
+                        "category": None,
+                        "detail_type": "String",
+                        "doc": None,
+                        "examples": [],
+                        "required": False,
+                        "type": "keyword"
+                    }
+                },
+                "required": False,
+                "type": "SubRecord"
+            },
+            "ip": {
+                "category": None,
+                "detail_type": "Long",
+                "doc": "The IP Address of the host",
+                "examples": [],
+                "required": False,
+                "type": "long"
+            },
+            "ipstr": {
+                "category": None,
+                "detail_type": "IPv4Address",
+                "doc": None,
+                "examples": [
+                    "8.8.8.8"
+                ],
+                "required": True,
+                "type": "ip"
+            },
+            "tags": {
+                "category": None,
+                "detail_type": "String",
+                "doc": None,
+                "examples": [],
+                "repeated": True,
+                "required": False,
+                "type": "keyword"
+            }
+        },
+        "required": False,
+        "type": "Record"
+    }
+}
+
+VALID_DOCS_OUTPUT_FOR_BIG_QUERY_FIELDS = {
+    "host": {
+        "category": None,
+        "doc": None,
+        "fields": {
+            "ip": {
+                "category": None,
+                "detail_type": "Long",
+                "doc": "The IP Address of the host",
+                "examples": [],
+                "required": False,
+                "type": "INTEGER"
+            },
+            "ipstr": {
+                "category": None,
+                "detail_type": "IPv4Address",
+                "doc": None,
+                "examples": [
+                    "8.8.8.8"
+                ],
+                "required": True,
+                "type": "STRING"
+            },
+            "p443": {
+                "category": "heartbleed",
+                "doc": None,
+                "fields": {
+                    "heartbleed": {
+                        "category": None,
+                        "doc": None,
+                        "fields": {
+                            "heartbeat_support": {
+                                "category": None,
+                                "detail_type": "Boolean",
+                                "doc": None,
+                                "examples": [],
+                                "required": False,
+                                "type": "BOOLEAN"
+                            },
+                            "heartbleed_vulnerable": {
+                                "category": "Vulnerabilities",
+                                "detail_type": "Boolean",
+                                "doc": None,
+                                "examples": [],
+                                "required": False,
+                                "type": "BOOLEAN"
+                            },
+                            "timestamp": {
+                                "category": None,
+                                "detail_type": "DateTime",
+                                "doc": None,
+                                "examples": [],
+                                "required": False,
+                                "type": "DATETIME"
+                            }
+                        },
+                        "required": False,
+                        "type": "SubRecord"
+                    },
+                    "tls": {
+                        "category": None,
+                        "detail_type": "String",
+                        "doc": None,
+                        "examples": [],
+                        "required": False,
+                        "type": "STRING"
+                    }
+                },
+                "required": False,
+                "type": "SubRecord"
+            },
+            "tags": {
+                "category": None,
+                "detail_type": "String",
+                "doc": None,
+                "examples": [],
+                "repeated": True,
+                "required": False,
+                "type": "STRING"
+            }
+        },
+        "required": False,
+        "type": "Record"
+    }
+}
+
 VALID_BIG_QUERY = [
     {
         "fields": [
@@ -177,6 +349,15 @@ class CompileAndValidationTests(unittest.TestCase):
         global VALID_ELASTIC_SEARCH
         r = self.host.to_es("host")
         self.assertEqual(r, VALID_ELASTIC_SEARCH)
+
+    def test_docs_output(self):
+        global VALID_DOCS_OUTPUT_FOR_ES_FIELDS
+        r = self.host.docs_es("host")
+        self.assertEqual(r, VALID_DOCS_OUTPUT_FOR_ES_FIELDS)
+
+        global VALID_DOCS_OUTPUT_FOR_BIG_QUERY_FIELDS
+        r = self.host.docs_bq("host")
+        self.assertEqual(r, VALID_DOCS_OUTPUT_FOR_BIG_QUERY_FIELDS)
 
     def test_validation_known_good(self):
         test = {


### PR DESCRIPTION
This PR adds two new output formats, `docs-es` and `docs-bq`. These formats are a JSON description of the schema, with a similar format between the two schemas. See https://gist.github.com/cdzombak/1d47457fd2b82f6e7bbe95508786c4a7 for example output based on the current ZTag schema.


This includes…

* The possible values for `Enum` leaves
* The `doc` field for records and leaves
* A new `examples` field, available on records and leaves
* The "detail type" for leaves. This is the type in our schema, and it'll be useful in cases where eg. BigQuery represents something as a string, but we internally represent it as a type that communicates more info (like an enum).
* A new cascading `category` property on records and leaves

The `category` field is intended to be a human-usable categorization of a record and its subrecords. This value cascades, so if you set it on a record it'll apply that category to all subrecords & leaves. A subrecord or leaf can also set a different category for itself and its children.

I have also removed some unused code/ivars/arguments, unimplemented methods, and soon-to-be-unused output formats (we'll use these annotated outputs to build better documentation tools).

closes https://github.com/zmap/zschema/issues/21