### PR TITLE
BigQuery Assertion NitPicks

### DIFF
--- a/zschema/tests.py
+++ b/zschema/tests.py
@@ -136,7 +136,8 @@ class CompileAndValidationTests(unittest.TestCase):
             return
         else:
             self.assertEquals(type(a), type(b))
-            if isinstance(a, collections.Iterable) and isinstance(a, collections.Iterable):
+            if isinstance(a, collections.Sized) \
+                    and isinstance(a, collections.Sized):
                 self.assertEquals(len(a), len(b))
             if isinstance(a, list):
                 for x, y in itertools.izip(sorted(a), sorted(b)):


### PR DESCRIPTION
This PR does the following:

(1) It makes the comparison between dictionaries an assertion (e.g., subclasses `AssertionError`). Before, two dictionaries could be inequal, in which case a `KeyError` would be raised instead of expected behavior of a failed assertion.

(2) Allows Python to take the first stab at comparing objects.  

(3) Checks whether two objects can have their length taken in a more pythonic manner

I _think_ we can just get rid of `self.assertEquals(type(a), type(b))`, but still pondering on that one a bit.