### PR TITLE
Re-work SubRecord.new() to be more useful

### DIFF
--- a/zschema/compounds.py
+++ b/zschema/compounds.py
@@ -94,8 +94,8 @@ class SubRecord(Keyable):
         for k, v in sorted(self.definition.iteritems()):
             _is_valid_object(k, v)
 
-    def new(self):
-        return copy.deepcopy(self)
+    def new(self, **kwargs):
+        return SubRecord({}, extends=self, **kwargs)
 
     def to_flat(self, parent, name, repeated=False):
         if repeated:

--- a/zschema/compounds.py
+++ b/zschema/compounds.py
@@ -95,6 +95,12 @@ class SubRecord(Keyable):
             _is_valid_object(k, v)
 
     def new(self, **kwargs):
+        # Get a new "instance" of the type represented by the SubRecord, e.g.:
+        # Certificate = SubRecord({...}, doc="A parsed certificate.")
+        # OtherType = SubRecord({
+        #   "ca": Certificate.new(doc="The CA certificate."),
+        #   "host": Certificate.new(doc="The host certificate.", required=True)
+        # })
         return SubRecord({}, extends=self, **kwargs)
 
     def to_flat(self, parent, name, repeated=False):

--- a/zschema/tests.py
+++ b/zschema/tests.py
@@ -612,5 +612,18 @@ class RegistryTests(unittest.TestCase):
         self.assertEqual(2, len(all_schemas))
 
 
+class SubRecordTests(unittest.TestCase):
+
+    def test_subrecord_child_types_can_override_parent_attributes(self):
+        Certificate = SubRecord({}, doc="A parsed certificate.")
+        OtherType = SubRecord({
+            "ca": Certificate.new(doc="The CA certificate."),
+            "host": Certificate.new(doc="The host certificate."),
+        })
+        self.assertEqual("A parsed certificate." , Certificate.doc)
+        self.assertEqual("The CA certificate.", OtherType.definition["ca"].doc)
+        self.assertEqual("The host certificate.", OtherType.definition["host"].doc)
+
+
 class NestedListOfTests(unittest.TestCase):
     pass


### PR DESCRIPTION
(i.e. allow docs, required, …etc to be overridden)

This may not be the final correct solution, but it seems to meet all of my requirements, as well as making `new()` act more closely to how I'd expected, without changing its behavior for any existing users -- we still end up calling `copy.deepcopy(self)`, it just ends up getting filtered through the full `SubRecord` constructor to do it.


