### PR TITLE
Subrecord Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Tests are run with [nose](http://nose.readthedocs.io/en/latest/). Run them via `
 License and Copyright
 ---------------------
 
-ZMap Copyright 2017 Regents of the University of Michigan
+ZSchema Copyright 2018 Regents of the University of Michigan
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License. You may obtain a copy of the

--- a/zschema/compounds.py
+++ b/zschema/compounds.py
@@ -215,7 +215,7 @@ def SubRecordType(definition,
         "definition":definition,
         "required":required,
         "allow_unknown":allow_unknown,
-        "exclude":exclude if exclude else set([]),
+        "_exclude":exclude if exclude else set([]),
         "category":category
     }
     return type("SubRecord", (SubRecord,), attrs)

--- a/zschema/compounds.py
+++ b/zschema/compounds.py
@@ -77,6 +77,7 @@ class SubRecord(Keyable):
             definition=None,
             required=False,
             doc=None,
+            extends=None
             allow_unknown=False,
             exclude=None,
             category=None):

--- a/zschema/compounds.py
+++ b/zschema/compounds.py
@@ -94,8 +94,14 @@ class SubRecord(Keyable):
         for k, v in sorted(self.definition.iteritems()):
             _is_valid_object(k, v)
 
-    def new(self):
-        return copy.deepcopy(self)
+    def new(self, **kwargs):
+        # Get a new "instance" of the type represented by the SubRecord, e.g.:
+        # Certificate = SubRecord({...}, doc="A parsed certificate.")
+        # OtherType = SubRecord({
+        #   "ca": Certificate.new(doc="The CA certificate."),
+        #   "host": Certificate.new(doc="The host certificate.", required=True)
+        # })
+        return SubRecord({}, extends=self, **kwargs)
 
     def to_flat(self, parent, name, repeated=False):
         if repeated:

--- a/zschema/compounds.py
+++ b/zschema/compounds.py
@@ -225,8 +225,6 @@ def SubRecordType(definition,
     return type("SubRecord", (SubRecord,), attrs)
 
 
-
-
 class NestedListOf(ListOf):
 
     def __init__(self, object_, subrecord_name, max_items=10, doc=None, category=None):

--- a/zschema/compounds.py
+++ b/zschema/compounds.py
@@ -12,11 +12,11 @@ def _is_valid_object(name, object_):
 class ListOf(Keyable):
 
     def __init__(self, object_, max_items=None, doc=None, category=None):
-        self.object_ = object_
-        self.max_items = max_items
-        self.category = category
-        self.doc = doc
-        _is_valid_object("Anonymous ListOf", object_)
+        self.replace_set("object_", object_)
+        self.replace_set("max_items", max_items)
+        self.replace_set("category", category)
+        self.replace_set("doc", doc)
+        _is_valid_object("Anonymous ListOf", self.object_)
 
     @property
     def exclude_bigquery(self):
@@ -88,10 +88,6 @@ def ListOfType(object_,
 
 
 class SubRecord(Keyable):
-
-    def replace_set(self, k, v):
-        if not hasattr(self, k) or v is not None:
-            setattr(self, k, v)
 
     def __init__(self,
             definition=None,

--- a/zschema/compounds.py
+++ b/zschema/compounds.py
@@ -11,7 +11,7 @@ def _is_valid_object(name, object_):
 
 class ListOf(Keyable):
 
-    def __init__(self, object_, max_items=10, doc=None, category=None):
+    def __init__(self, object_, max_items=None, doc=None, category=None):
         self.object_ = object_
         self.max_items = max_items
         self.category = category
@@ -72,6 +72,19 @@ class ListOf(Keyable):
             yield rec
 
 
+def ListOfType(object_,
+        max_items=None,
+        doc=None,
+        category=None):
+    attrs = {
+        "object_":definition,
+        "max_items":None,
+        "doc":doc,
+        "category":category,
+    }
+    return type("ListOf", (ListOf,), attrs)
+
+
 class SubRecord(Keyable):
 
     def replace_set(self, k, v):
@@ -99,7 +112,6 @@ class SubRecord(Keyable):
         if self.definition:
             for k, v in sorted(self.definition.iteritems()):
                 _is_valid_object(k, v)
-
 
     def new(self, **kwargs):
         # Get a new "instance" of the type represented by the SubRecord, e.g.:
@@ -233,6 +245,7 @@ def SubRecordType(definition,
         "category":category
     }
     return type("SubRecord", (SubRecord,), attrs)
+
 
 
 class NestedListOf(ListOf):

--- a/zschema/compounds.py
+++ b/zschema/compounds.py
@@ -73,6 +73,10 @@ class ListOf(Keyable):
 
 class SubRecord(Keyable):
 
+    def replace_set(self, k, v):
+        if not hasattr(self, k) or v is not None:
+            setattr(self, k, v)
+
     def __init__(self,
             definition=None,
             required=False,
@@ -81,29 +85,24 @@ class SubRecord(Keyable):
             allow_unknown=False,
             exclude=None,
             category=None):
-        if definition:
-            self.definition = definition
-        if not self.definition:
-            raise Exception("SubRecord type has no defined definition")
-        if required is not None:
-            self.required = required
-        if allow_unknown is not None:
-            self.allow_unknown = allow_unknown
-        if doc is not None:
-            self.doc = doc
-        if category is not None:
-            self.category = category
-        if exclude is not None:
-            self._exclude = set(exclude) if exclude else set([])
-        if not hasattr(self, "_exclude"):
-            self._exclude = set([])
-        if extends:
+        self.definition = definition
+        #self.replace_set("definition", definition)
+        #print definition
+        #print self.definition
+        #if not self.definition:
+        #    raise Exception("SubRecord has no defined definition")
+        self.replace_set("required", required)
+        self.replace_set("allow_unknown", allow_unknown)
+        self.replace_set("doc", doc)
+        self.replace_set("category", category)
+        self.replace_set("_exclude", set(exclude) if exclude else set([]))
+        if extends is not None:
             extends = copy.deepcopy(extends)
             self.definition = self.merge(extends).definition
         # safety check
-        for k, v in sorted(self.definition.iteritems()):
-            _is_valid_object(k, v)
-
+        if self.definition:
+            for k, v in sorted(self.definition.iteritems()):
+                _is_valid_object(k, v)
 
     def to_flat(self, parent, name, repeated=False):
         if repeated:
@@ -218,6 +217,7 @@ def SubRecordType(definition,
     attrs = {
         "definition":definition,
         "required":required,
+        "doc":doc,
         "allow_unknown":allow_unknown,
         "_exclude":exclude if exclude else set([]),
         "category":category

--- a/zschema/compounds.py
+++ b/zschema/compounds.py
@@ -85,12 +85,7 @@ class SubRecord(Keyable):
             allow_unknown=False,
             exclude=None,
             category=None):
-        self.definition = definition
-        #self.replace_set("definition", definition)
-        #print definition
-        #print self.definition
-        #if not self.definition:
-        #    raise Exception("SubRecord has no defined definition")
+        self.replace_set("definition", definition)
         self.replace_set("required", required)
         self.replace_set("allow_unknown", allow_unknown)
         self.replace_set("doc", doc)

--- a/zschema/compounds.py
+++ b/zschema/compounds.py
@@ -77,7 +77,7 @@ class SubRecord(Keyable):
             definition=None,
             required=False,
             doc=None,
-            extends=None
+            extends=None,
             allow_unknown=False,
             exclude=None,
             category=None):

--- a/zschema/compounds.py
+++ b/zschema/compounds.py
@@ -11,10 +11,11 @@ def _is_valid_object(name, object_):
 
 class ListOf(Keyable):
 
-    def __init__(self, object_, max_items=None, doc=None, category=None):
+    def __init__(self, object_, required=None, max_items=None, doc=None, category=None):
         self.replace_set("object_", object_)
         self.replace_set("max_items", max_items)
         self.replace_set("category", category)
+        self.replace_set("required", required)
         self.replace_set("doc", doc)
         _is_valid_object("Anonymous ListOf", self.object_)
 
@@ -322,3 +323,4 @@ class Record(SubRecord):
     @classmethod
     def from_json(cls, j):
         return cls({(k, __encode(v)) for k, v in sorted(j.iteritems())})
+

--- a/zschema/compounds.py
+++ b/zschema/compounds.py
@@ -96,6 +96,9 @@ class SubRecord(Keyable):
             self._exclude = set(exclude) if exclude else set([])
         if not hasattr(self, "_exclude"):
             self._exclude = set([])
+        if extends:
+            extends = copy.deepcopy(extends)
+            self.definition = self.merge(extends).definition
         # safety check
         for k, v in sorted(self.definition.iteritems()):
             _is_valid_object(k, v)

--- a/zschema/compounds.py
+++ b/zschema/compounds.py
@@ -76,9 +76,11 @@ def ListOfType(object_,
         max_items=None,
         doc=None,
         category=None):
+
+    _is_valid_object("Anonymous ListOf", object_)
     attrs = {
-        "object_":definition,
-        "max_items":None,
+        "object_":object_,
+        "max_items":max_items,
         "doc":doc,
         "category":category,
     }

--- a/zschema/compounds.py
+++ b/zschema/compounds.py
@@ -1,3 +1,4 @@
+import sys
 import copy
 import json
 
@@ -98,6 +99,19 @@ class SubRecord(Keyable):
         if self.definition:
             for k, v in sorted(self.definition.iteritems()):
                 _is_valid_object(k, v)
+
+
+    def new(self, **kwargs):
+        # Get a new "instance" of the type represented by the SubRecord, e.g.:
+        # Certificate = SubRecord({...}, doc="A parsed certificate.")
+        # OtherType = SubRecord({
+        #   "ca": Certificate.new(doc="The CA certificate."),
+        #   "host": Certificate.new(doc="The host certificate.", required=True)
+        # })
+        e = "WARN: .new() is deprecated and will be removed in a "\
+                "future release. Schemas should use SubRecordTypes.\n"
+        sys.stderr.write(e)
+        return SubRecord({}, extends=self, **kwargs)
 
     def to_flat(self, parent, name, repeated=False):
         if repeated:

--- a/zschema/compounds.py
+++ b/zschema/compounds.py
@@ -74,14 +74,15 @@ class ListOf(Keyable):
 
 
 def ListOfType(object_,
+        required=None,
         max_items=None,
         doc=None,
         category=None):
-
     _is_valid_object("Anonymous ListOf", object_)
     attrs = {
         "object_":object_,
         "max_items":max_items,
+        "required":required,
         "doc":doc,
         "category":category,
     }

--- a/zschema/keys.py
+++ b/zschema/keys.py
@@ -84,6 +84,10 @@ class Keyable(object):
         else:
             return o.to_string()
 
+    def replace_set(self, k, v):
+        if not hasattr(self, k) or v is not None:
+            setattr(self, k, v)
+
     @property
     def exclude_bigquery(self):
         return "bigquery" in self._exclude

--- a/zschema/leaves.py
+++ b/zschema/leaves.py
@@ -276,6 +276,7 @@ class HTML(AnalyzedString):
 
 
 class IPAddress(Leaf):
+
     ES_TYPE = "ip"
     BQ_TYPE = "STRING"
     EXPECTED_CLASS = [str,unicode]
@@ -296,17 +297,9 @@ class IPAddress(Leaf):
 class IPv4Address(IPAddress):
     pass
 
+class _Integer(Leaf):
 
-class Signed32BitInteger(Leaf):
-
-    ES_TYPE = "integer"
-    BQ_TYPE = "INTEGER"
     EXPECTED_CLASS = [int,]
-
-    INVALID = 8589934592
-    VALID = 234234252
-
-    BITS = 32
 
     def _validate(self, name, value):
         max_ = 2**self.BITS - 1
@@ -319,7 +312,18 @@ class Signed32BitInteger(Leaf):
                     name, str(value), str(min_)))
 
 
-class Signed8BitInteger(Leaf):
+class Signed32BitInteger(_Integer):
+
+    ES_TYPE = "integer"
+    BQ_TYPE = "INTEGER"
+
+    INVALID = 8589934592
+    VALID = 234234252
+
+    BITS = 32
+
+
+class Signed8BitInteger(_Integer):
 
     ES_TYPE = "byte"
     BITS = 8
@@ -327,12 +331,13 @@ class Signed8BitInteger(Leaf):
     VALID = 34
 
 
-class Signed16BitInteger(Leaf):
+class Signed16BitInteger(_Integer):
 
     ES_TYPE = "short"
     BITS = 16
     INVALID = 2**16
     VALID = 0xFFFF
+    EXPECTED_CLASS = [int,]
 
 
 class Unsigned8BitInteger(Signed16BitInteger):
@@ -343,7 +348,7 @@ class Unsigned16BitInteger(Signed32BitInteger):
     pass
 
 
-class Signed64BitInteger(Leaf):
+class Signed64BitInteger(_Integer):
 
     ES_TYPE = "long"
     BQ_TYPE = "INTEGER"
@@ -355,11 +360,6 @@ class Signed64BitInteger(Leaf):
 
 class Unsigned32BitInteger(Signed64BitInteger):
     pass
-
-
-class Long(Signed64BitInteger):
-
-    DEPRECATED = True
 
 
 class Float(Leaf):

--- a/zschema/leaves.py
+++ b/zschema/leaves.py
@@ -319,12 +319,7 @@ class Signed32BitInteger(Leaf):
                     name, str(value), str(min_)))
 
 
-class Integer(Signed32BitInteger):
-
-    DEPRECATED = True
-
-
-class Signed8BitInteger(Integer):
+class Signed8BitInteger(Leaf):
 
     ES_TYPE = "byte"
     BITS = 8
@@ -332,18 +327,12 @@ class Signed8BitInteger(Integer):
     VALID = 34
 
 
-class Byte(Signed8BitInteger):
-
-    DEPRECATED = True
-
-
-class Signed16BitInteger(Integer):
+class Signed16BitInteger(Leaf):
 
     ES_TYPE = "short"
     BITS = 16
     INVALID = 2**16
     VALID = 0xFFFF
-    DEPRECATED = False
 
 
 class Unsigned8BitInteger(Signed16BitInteger):
@@ -354,12 +343,7 @@ class Unsigned16BitInteger(Signed32BitInteger):
     pass
 
 
-class Short(Signed16BitInteger):
-
-    DEPRECATED = True
-
-
-class Signed64BitInteger(Integer):
+class Signed64BitInteger(Leaf):
 
     ES_TYPE = "long"
     BQ_TYPE = "INTEGER"
@@ -367,7 +351,6 @@ class Signed64BitInteger(Integer):
     INVALID = 2l**68
     VALID = 10l
     BITS = 64
-    DEPRECATED = False
 
 
 class Unsigned32BitInteger(Signed64BitInteger):
@@ -552,10 +535,6 @@ VALID_LEAVES = [
     Boolean,
     Double,
     Float,
-    Long,
-    Short,
-    Byte,
-    Integer,
     IPv4Address,
     IPAddress,
     Enum,

--- a/zschema/tests.py
+++ b/zschema/tests.py
@@ -569,6 +569,30 @@ class CompileAndValidationTests(unittest.TestCase):
         })
         ipv4_host_ssh.validate(json_fixture('ipv4-ssh-record'))
 
+    def test_subrecord_types(self):
+        SSH = SubRecordType({
+            "banner":SubRecord({
+                "comment":String(),
+                "timestamp":DateTime()
+                })
+            },
+            doc="class doc",
+            required=False)
+        self.assertEqual(SSH.doc, "class doc")
+        self.assertEqual(SSH.required, False)
+        ssh = SSH(doc="instance doc", required=True)
+        ipv4_host_ssh = Record({
+            Port(22):SubRecord({
+                "ssh":ssh
+            })
+        })
+        self.assertEqual(ssh.doc, "instance doc")
+        self.assertEqual(ssh.required, True)
+        ipv4_host_ssh.validate(json_fixture('ipv4-ssh-record'))
+        # class unchanged
+        self.assertEqual(SSH.doc, "class doc")
+        self.assertEqual(SSH.required, False)
+
 
 class RegistryTests(unittest.TestCase):
 

--- a/zschema/tests.py
+++ b/zschema/tests.py
@@ -122,7 +122,7 @@ VALID_DOCS_OUTPUT_FOR_ES_FIELDS = {
             },
             "ip": {
                 "category": None,
-                "detail_type": "Long",
+                "detail_type": "Unsigned32BitInteger",
                 "doc": "The IP Address of the host",
                 "examples": [],
                 "required": False,
@@ -160,7 +160,7 @@ VALID_DOCS_OUTPUT_FOR_BIG_QUERY_FIELDS = {
         "fields": {
             "ip": {
                 "category": None,
-                "detail_type": "Long",
+                "detail_type": "Unsigned32BitInteger",
                 "doc": "The IP Address of the host",
                 "examples": [],
                 "required": False,
@@ -332,7 +332,7 @@ class CompileAndValidationTests(unittest.TestCase):
         })
         self.host = Record({
                 "ipstr":IPv4Address(required=True, examples=["8.8.8.8"]),
-                "ip":Long(doc="The IP Address of the host"),
+                "ip":Unsigned32BitInteger(doc="The IP Address of the host"),
                 Port(443):SubRecord({
                     "tls":String(),
                     "heartbleed":heartbleed

--- a/zschema/tests.py
+++ b/zschema/tests.py
@@ -615,10 +615,10 @@ class RegistryTests(unittest.TestCase):
 class SubRecordTests(unittest.TestCase):
 
     def test_subrecord_child_types_can_override_parent_attributes(self):
-        Certificate = SubRecord({}, doc="A parsed certificate.")
+        Certificate = SubRecordType({}, doc="A parsed certificate.")
         OtherType = SubRecord({
-            "ca": Certificate.new(doc="The CA certificate."),
-            "host": Certificate.new(doc="The host certificate."),
+            "ca": Certificate(doc="The CA certificate."),
+            "host": Certificate(doc="The host certificate."),
         })
         self.assertEqual("A parsed certificate." , Certificate.doc)
         self.assertEqual("The CA certificate.", OtherType.definition["ca"].doc)

--- a/zschema/tests.py
+++ b/zschema/tests.py
@@ -612,5 +612,18 @@ class RegistryTests(unittest.TestCase):
         self.assertEqual(2, len(all_schemas))
 
 
+class SubRecordTests(unittest.TestCase):
+
+    def test_subrecord_child_types_can_override_parent_attributes(self):
+        Certificate = SubRecord({}, doc="A parsed certificate.")
+        OtherType = SubRecord({
+            "ca": Certificate.new(doc="The CA certificate."),
+            "host": Certificate.new(doc="The host certificate."),
+        })
+        self.assertEqual("A parsed certificate." , Certificate.doc)
+        self.assertEqual("The CA certificate.", OtherType.definition["ca"].doc)
+        self.assertEqual("The host certificate.", OtherType.definition["host"].doc)
+
+
 class NestedListOfTests(unittest.TestCase):
     pass

--- a/zschema/tests.py
+++ b/zschema/tests.py
@@ -580,6 +580,32 @@ class CompileAndValidationTests(unittest.TestCase):
             required=False)
         self.assertEqual(SSH.doc, "class doc")
         self.assertEqual(SSH.required, False)
+        ssh = SSH(doc="instance doc")
+        ipv4_host_ssh = Record({
+            Port(22):SubRecord({
+                "ssh":ssh
+            })
+        })
+        self.assertEqual(ssh.doc, "instance doc")
+        self.assertEqual(ssh.required, False)
+        ipv4_host_ssh.validate(json_fixture('ipv4-ssh-record'))
+        # class unchanged
+        self.assertEqual(SSH.doc, "class doc")
+        self.assertEqual(SSH.required, False)
+
+
+
+    def test_subrecord_type_override(self):
+        SSH = SubRecordType({
+            "banner":SubRecord({
+                "comment":String(),
+                "timestamp":DateTime()
+                })
+            },
+            doc="class doc",
+            required=False)
+        self.assertEqual(SSH.doc, "class doc")
+        self.assertEqual(SSH.required, False)
         ssh = SSH(doc="instance doc", required=True)
         ipv4_host_ssh = Record({
             Port(22):SubRecord({
@@ -592,6 +618,8 @@ class CompileAndValidationTests(unittest.TestCase):
         # class unchanged
         self.assertEqual(SSH.doc, "class doc")
         self.assertEqual(SSH.required, False)
+
+
 
 
 class RegistryTests(unittest.TestCase):

--- a/zschema/tests.py
+++ b/zschema/tests.py
@@ -620,8 +620,6 @@ class CompileAndValidationTests(unittest.TestCase):
         self.assertEqual(SSH.required, False)
 
 
-
-
 class RegistryTests(unittest.TestCase):
 
     def setUp(self):
@@ -672,7 +670,7 @@ class SubRecordTests(unittest.TestCase):
             "ca": Certificate(doc="The CA certificate."),
             "host": Certificate(doc="The host certificate."),
         })
-        self.assertEqual("A parsed certificate." , Certificate.doc)
+        self.assertEqual("A parsed certificate." , Certificate().doc)
         self.assertEqual("The CA certificate.", OtherType.definition["ca"].doc)
         self.assertEqual("The host certificate.", OtherType.definition["host"].doc)
 


### PR DESCRIPTION
This adds types as subclasses.

So now you can do something like this:
```
SSH = SubRecordType({
   "banner":SubRecord({
       "comment":String(),
       "timestamp":DateTime()
       })
   })

Record({
    "ssh":SSH(doc="instance doc", required=True)
})
```