### PR TITLE
Enums without possible values have an empty values property

### DIFF
--- a/zschema/leaves.py
+++ b/zschema/leaves.py
@@ -83,11 +83,8 @@ class Leaf(Keyable):
             "category": self.category or parent_category,
             "doc": self.doc,
             "required": self.required,
+            "examples": self.examples,
         }
-        if hasattr(self, "values_s") and len(self.values_s):
-            retv["values"] = list(self.values_s)
-        else:
-            retv["examples"] = self.examples
         return retv
 
     def docs_es(self, parent_category=None):
@@ -246,16 +243,24 @@ class Enum(Leaf):
     INVALID = 23
     VALID = None
 
-    def __init__(self, values=[None,], *args, **kwargs):
+    def __init__(self, values=None, *args, **kwargs):
         Leaf.__init__(self, *args, **kwargs)
+        if values is None:
+            values = []
         self.values = values
         self.values_s = set(values)
 
     def _validate(self, name, value):
-        if value not in self.values_s:
+        if len(self.values_s) and value not in self.values_s:
             m = "%s: the value %s is not a valid enum option" % (name, value)
             raise DataValidationException(m)
 
+    def _docs_common(self, parent_category):
+        retv = super(Enum, self)._docs_common(parent_category)
+        if len(self.values_s):
+            retv["values"] = list(self.values_s)
+            del retv["examples"]
+        return retv
 
 class HTML(AnalyzedString):
 


### PR DESCRIPTION
Before this PR, an Enum leaf without values (used in a schema like `Enum()`) would have `values` and `values_s` properties that were a list/set containing a single value, `None`. This didn’t make sense to me, and it complicated producing clean documentation output.

Instead, for the “any values are accepted” case, we’ll keep those two `Enum` properties as an empty list & set, and check for this specific case when validating a document against a schema.

Finally, this PR cleans up the code that produces documentation for Enum leaves.