### PR TITLE
add Keyable.with_args + tests

### DIFF
--- a/zschema/keys.py
+++ b/zschema/keys.py
@@ -33,12 +33,16 @@ class Port(object):
 # Create a dict with all the keys / values of rhs and lhs, where values
 # from lhs are used if a key is in both.
 def left_merge(lhs, rhs):
-    return dict(v for v in rhs.items() + lhs.items())
-
+    ret = rhs.copy()
+    ret.update(lhs)
+    return ret
 
 # Factory for TypeFactorys (e.g. SubRecordType is a TypeFactory for
 # SubRecords).
-class TypeFactoryFactory():
+class TypeFactoryFactory(object):
+    # This factory acts as a constructor for cls with the first 
+    # len(args) positional arguments fixed by args, and with kwargs 
+    # serving as the default keyword arguments.
     def __init__(self, cls, args, kwargs):
         self.args = args
         self.kwargs = kwargs
@@ -47,8 +51,8 @@ class TypeFactoryFactory():
     # Returns a TypeFactory that returns type instances of cls, using
     # the args positional arguments, and using kwargs as the default
     # values for any keyword arguments.
-    def __call__(self, **kwargs):
-        return self.cls(*self.args, **left_merge(kwargs, self.kwargs))
+    def __call__(self, *args, **kwargs):
+        return self.cls(*(self.args + args), **left_merge(kwargs, self.kwargs))
 
 
 class Keyable(object):

--- a/zschema/keys.py
+++ b/zschema/keys.py
@@ -46,13 +46,30 @@ class TypeFactoryFactory(object):
     SubRecords).
     """
 
-    def __init__(self, cls, args, kwargs):
+    def __init__(self, cls, args=None, kwargs=None):
         """
         This factory acts as a constructor for cls with the first
         len(args) positional arguments fixed by args, and with kwargs
         serving as the default keyword arguments.
+        Note: the positional args can be set here, or in the later call,
+        but not in both.
         """
-        self.args = args
+        if not callable(cls):
+            raise Exception("cls must be callable.")
+
+        if args and not isinstance(args, (list, tuple)):
+            raise Exception("If present, args must be a list or a tuple.")
+
+        if kwargs and not isinstance(kwargs, dict):
+            raise Exception("If present, kwargs must be a dict.")
+
+        if args is None:
+            args = []
+
+        if kwargs is None:
+            kwargs = {}
+
+        self.args = tuple(args)
         self.kwargs = kwargs
         self.cls = cls
 
@@ -62,7 +79,11 @@ class TypeFactoryFactory(object):
         the args positional arguments, and using kwargs as the default
         values for any keyword arguments.
         """
-        return self.cls(*(self.args + args), **left_merge(kwargs, self.kwargs))
+        if len(args) > 0 and len(self.args) > 0:
+            raise Exception("Positional arguments already bound during TypeFactory creation.")
+        if len(args) == 0:
+            args = self.args
+        return self.cls(*args, **left_merge(kwargs, self.kwargs))
 
 
 class Keyable(object):

--- a/zschema/keys.py
+++ b/zschema/keys.py
@@ -30,28 +30,38 @@ class Port(object):
             return cmp(int(self.port), int(other.port))
 
 
-# Create a dict with all the keys / values of rhs and lhs, where values
-# from lhs are used if a key is in both.
 def left_merge(lhs, rhs):
+    """
+    Create a dict with all the keys / values of rhs and lhs, where
+    from lhs are used if a key is in both.
+    """
     ret = rhs.copy()
     ret.update(lhs)
     return ret
 
-# Factory for TypeFactorys (e.g. SubRecordType is a TypeFactory for
-# SubRecords).
+
 class TypeFactoryFactory(object):
-    # This factory acts as a constructor for cls with the first 
-    # len(args) positional arguments fixed by args, and with kwargs 
-    # serving as the default keyword arguments.
+    """
+    Factory for TypeFactorys (e.g. SubRecordType is a TypeFactory for
+    SubRecords).
+    """
+
     def __init__(self, cls, args, kwargs):
+        """
+        This factory acts as a constructor for cls with the first
+        len(args) positional arguments fixed by args, and with kwargs
+        serving as the default keyword arguments.
+        """
         self.args = args
         self.kwargs = kwargs
         self.cls = cls
 
-    # Returns a TypeFactory that returns type instances of cls, using
-    # the args positional arguments, and using kwargs as the default
-    # values for any keyword arguments.
     def __call__(self, *args, **kwargs):
+        """
+        Returns a TypeFactory that returns type instances of cls, using
+        the args positional arguments, and using kwargs as the default
+        values for any keyword arguments.
+        """
         return self.cls(*(self.args + args), **left_merge(kwargs, self.kwargs))
 
 
@@ -128,17 +138,25 @@ class Keyable(object):
             d[name] = getattr(self, default)
         return d
 
-    # Get a constructor for this type using the given positional
-    # arguments; any keyword arguments will act as defaults if they are
-    # not specified.
-    # Example:
-    # MyStringType = String.with_args(doc="Some docs for my string", category="my category")
-    # my_string_1 = MyStringType(doc="overridden docs")
-    # my_string_2 = MyStringType(examples=["a", "b", "c"])
-    # CertChain = ListOf.with_args(Certificate(doc="An element of the chain."), doc="A list of certificates.")
-    # my_chain = CertChain()
     @classmethod
     def with_args(cls, *args, **kwargs):
+        """
+        Get a constructor for this type using the given positional
+        arguments; any keyword arguments will act as defaults if they
+        not specified.
+
+        Examples:
+            >>> MyStringType = String.with_args(doc="Some docs for my string", category="my category")
+            >>> my_string_1 = MyStringType(doc="overridden docs")
+            >>> my_string_2 = MyStringType(examples=["a", "b", "c"])
+            >>> print my_string_1.doc, my_string_2.doc
+            "overridden docs", "Some docs for my string"
+
+            >>> CertChain = ListOf.with_args(Certificate(doc="An element of the chain."), doc="A list of certificates.")
+            >>> my_chain = CertChain()
+            >>> print my_chain.doc, my_chain.object_.doc
+            "A list of certificates", "An element of the chain."
+        """
         return TypeFactoryFactory(cls=cls, args=args, kwargs=kwargs)
 
     @classmethod

--- a/zschema/keys.py
+++ b/zschema/keys.py
@@ -55,13 +55,13 @@ class TypeFactoryFactory(object):
         but not in both.
         """
         if not callable(cls):
-            raise Exception("cls must be callable.")
+            raise TypeError("cls must be callable.")
 
         if args and not isinstance(args, (list, tuple)):
-            raise Exception("If present, args must be a list or a tuple.")
+            raise TypeError("If present, args must be a list or a tuple.")
 
         if kwargs and not isinstance(kwargs, dict):
-            raise Exception("If present, kwargs must be a dict.")
+            raise TypeError("If present, kwargs must be a dict.")
 
         if args is None:
             args = []

--- a/zschema/tests.py
+++ b/zschema/tests.py
@@ -675,3 +675,42 @@ class SubRecordTests(unittest.TestCase):
 
 class NestedListOfTests(unittest.TestCase):
     pass
+
+
+class WithArgsTests(unittest.TestCase):
+    def test_with_args(self):
+        Certificate = SubRecord.with_args({}, doc="A parsed certificate.")
+        CertificateChain = ListOf.with_args(Certificate())
+        AlgorithmType = String.with_args(doc="An algorithm identifier", examples=["a", "b", "c"])
+        OtherType = SubRecord({
+            "ca": Certificate(doc="The CA certificate."),
+            "host": Certificate(doc="The host certificate."),
+            "chain": CertificateChain(doc="The certificate chain."),
+            "host_alg": AlgorithmType(doc="The host algorithm", examples=["x", "y"]),
+            "client_alg": AlgorithmType(doc="The client algorithm"),
+            "sig_alg": AlgorithmType(examples=["p", "q"]),
+        })
+        # Check default
+        self.assertEqual("A parsed certificate.", Certificate().doc)
+
+        # Check overridden
+        self.assertEqual("The CA certificate.", OtherType.definition["ca"].doc)
+        self.assertEqual("The host certificate.", OtherType.definition["host"].doc)
+
+        # Check ListOf
+        self.assertEqual("The certificate chain.", OtherType.definition["chain"].doc)
+
+        # Check that instance default is used in child
+        self.assertEqual("A parsed certificate.", OtherType.definition["chain"].object_.doc)
+
+        # Check Leaf type doc overrides
+        self.assertEqual("The host algorithm", OtherType.definition["host_alg"].doc)
+        self.assertEqual("The client algorithm", OtherType.definition["client_alg"].doc)
+        self.assertEqual("An algorithm identifier", OtherType.definition["sig_alg"].doc)
+
+        # Check that examples are inherited
+        self.assertEqual(["a", "b", "c"], OtherType.definition["client_alg"].examples)
+
+        # Check that examples are overridden
+        self.assertEqual(["x", "y"], OtherType.definition["host_alg"].examples)
+        self.assertEqual(["p", "q"], OtherType.definition["sig_alg"].examples)

--- a/zschema/tests.py
+++ b/zschema/tests.py
@@ -720,6 +720,7 @@ class WithArgsTests(unittest.TestCase):
             def __init__(self, *args, **kwargs):
                 self.args = args
                 self.kwargs = kwargs
+                self.doc = kwargs.get("doc")
 
         # Leave the positional argument (list type) blank, but specify a category.
         GenericCategorizedList = ListOf.with_args(category="my category")
@@ -736,11 +737,14 @@ class WithArgsTests(unittest.TestCase):
         # ListOf(...) needs exactly one positional arg, so GenericCategorizedList() should also raise.
         self.assertRaises(lambda: CategorizedCertificateList())
 
-        # Confirm that args are appended as expected.
-        MyPositional = Positional.with_args("a")
+        # Confirm that positional args are pulled from the proper location
+        MyPositional = Positional.with_args("a", doc="default docs")
         p0 = MyPositional()
-        p1 = MyPositional("b")
-        p2 = MyPositional("x", "y")
+        p0doc = MyPositional(doc="some docs")
+        # Passing positional args to the factory constructor and the contructor is not allowed
+        self.assertRaises(lambda: MyPositional("b"))
+        self.assertRaises(lambda: MyPositional("x, y"))
         self.assertEqual(("a",), p0.args)
-        self.assertEqual(("a", "b",), p1.args)
-        self.assertEqual(("a", "x", "y",), p2.args)
+        self.assertEqual("default docs", p0.doc)
+        self.assertEqual(("a",), p0doc.args)
+        self.assertEqual("some docs", p0doc.doc)


### PR DESCRIPTION
Proposed solution to problem of needing `StringType`, `EnumType`, `AnalyzedStringType`, ...

Now every subclass of `Keyable` has a `with_args` class method that can be used to get a constructor with some or all of its arguments pre-bound.

Note that this is being merged into subrecord-types, not master.