### PR TITLE
Bugfixes to support validating our current schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyo
 *.pyc
-.*
+
+.eggs/
 dist/*
 zschema.egg-info/*
 build/*

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ dist/*
 zschema.egg-info/*
 build/*
 MANIFEST
+
+# IntelliJ IDEA
+.idea/
+*.iml

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
 
     install_requires = [
         "python-dateutil",
+        "pytz",
     ],
 
     packages = [

--- a/zschema/compounds.py
+++ b/zschema/compounds.py
@@ -11,13 +11,12 @@ def _is_valid_object(name, object_):
 
 class ListOf(Keyable):
 
-    def __init__(self, object_, required=None, max_items=None, doc=None, category=None, validator=None):
+    def __init__(self, object_, required=None, max_items=None, doc=None, category=None):
         self.replace_set("object_", object_)
         self.replace_set("max_items", max_items)
         self.replace_set("category", category)
         self.replace_set("required", required)
         self.replace_set("doc", doc)
-        self.replace_set("validator", validator)
         _is_valid_object("Anonymous ListOf", self.object_)
 
     @property
@@ -60,9 +59,6 @@ class ListOf(Keyable):
         return retv
 
     def validate(self, name, value):
-        if self.validator:
-            self.validator.validate(name, value)
-            return
         if type(value) != list:
             raise DataValidationException("%s: %s is not a list",
                                           name, str(value))
@@ -102,14 +98,12 @@ class SubRecord(Keyable):
             extends=None,
             allow_unknown=False,
             exclude=None,
-            category=None,
-            validator=None):
+            category=None):
         self.replace_set("definition", definition)
         self.replace_set("required", required)
         self.replace_set("allow_unknown", allow_unknown)
         self.replace_set("doc", doc)
         self.replace_set("category", category)
-        self.replace_set("validator", validator)
         self.replace_set("_exclude", set(exclude) if exclude else set([]))
         if extends is not None:
             extends = copy.deepcopy(extends)
@@ -225,9 +219,6 @@ class SubRecord(Keyable):
         return {"type":"subrecord", "subfields": p, "doc":self.doc, "required":self.required}
 
     def validate(self, name, value):
-        if self.validator:
-            self.validator.validate(name, value)
-            return
         if type(value) != dict:
             raise DataValidationException("%s: %s is not a dict",
                                           name, str(value))

--- a/zschema/compounds.py
+++ b/zschema/compounds.py
@@ -305,8 +305,7 @@ class Record(SubRecord):
             raise DataValidationException("record is not a dict", str(value))
         for subkey, subvalue in sorted(value.iteritems()):
             if subkey not in self.definition:
-                raise DataValidationException("%s is not a valid subkey of root",
-                                              subkey)
+                raise DataValidationException("%s is not a valid subkey of root" % subkey)
             self.definition[subkey].validate(subkey, subvalue)
 
     def to_dict(self):

--- a/zschema/compounds.py
+++ b/zschema/compounds.py
@@ -11,12 +11,13 @@ def _is_valid_object(name, object_):
 
 class ListOf(Keyable):
 
-    def __init__(self, object_, required=None, max_items=None, doc=None, category=None):
+    def __init__(self, object_, required=None, max_items=None, doc=None, category=None, validator=None):
         self.replace_set("object_", object_)
         self.replace_set("max_items", max_items)
         self.replace_set("category", category)
         self.replace_set("required", required)
         self.replace_set("doc", doc)
+        self.replace_set("validator", validator)
         _is_valid_object("Anonymous ListOf", self.object_)
 
     @property
@@ -59,6 +60,9 @@ class ListOf(Keyable):
         return retv
 
     def validate(self, name, value):
+        if self.validator:
+            self.validator.validate(name, value)
+            return
         if type(value) != list:
             raise DataValidationException("%s: %s is not a list",
                                           name, str(value))
@@ -98,12 +102,14 @@ class SubRecord(Keyable):
             extends=None,
             allow_unknown=False,
             exclude=None,
-            category=None):
+            category=None,
+            validator=None):
         self.replace_set("definition", definition)
         self.replace_set("required", required)
         self.replace_set("allow_unknown", allow_unknown)
         self.replace_set("doc", doc)
         self.replace_set("category", category)
+        self.replace_set("validator", validator)
         self.replace_set("_exclude", set(exclude) if exclude else set([]))
         if extends is not None:
             extends = copy.deepcopy(extends)
@@ -219,6 +225,9 @@ class SubRecord(Keyable):
         return {"type":"subrecord", "subfields": p, "doc":self.doc, "required":self.required}
 
     def validate(self, name, value):
+        if self.validator:
+            self.validator.validate(name, value)
+            return
         if type(value) != dict:
             raise DataValidationException("%s: %s is not a dict",
                                           name, str(value))

--- a/zschema/compounds.py
+++ b/zschema/compounds.py
@@ -342,12 +342,11 @@ class Record(SubRecord):
         calculated_policy = self._calculate_policy("root", policy, self.validation_policy)
         # ^ note: record explicitly does not take a parent_policy
         if type(value) != dict:
-            raise DataValidationException("record is not a dict", str(value))
+            raise DataValidationException("record is not a dict:\n{}".format(value))
         for subkey, subvalue in sorted(value.iteritems()):
             try:
                 if subkey not in self.definition:
-                    raise DataValidationException("%s is not a valid subkey of root",
-                                                  subkey)
+                    raise DataValidationException("%s is not a valid subkey of root" % subkey)
                 self.definition[subkey].validate(subkey, subvalue, policy,
                         self.validation_policy)
             except DataValidationException as e:

--- a/zschema/keys.py
+++ b/zschema/keys.py
@@ -178,6 +178,7 @@ class Keyable(object):
             raise e
         if policy == "error":
             e.force = True
+            logging.error(e.message)
             raise e
         elif policy == "warn":
             logging.warn(e.message)

--- a/zschema/leaves.py
+++ b/zschema/leaves.py
@@ -149,22 +149,24 @@ class Leaf(Keyable):
         print val
 
     def validate(self, name, value):
-        validator = self.validator or self
-        if not validator._check_valid_name(name):
+        if self.validator:
+            self.validator.validate(name, value)
+            return
+        if not self._check_valid_name(name):
             raise DataValidationException("Invalid field name: %s" % name)
         if value is None:
-            if validator.required:
+            if self.required:
                 raise DataValidationException("%s is a required field, but "
                                               "recieved None" % name)
             else:
                 return
-        if type(value) not in validator.EXPECTED_CLASS:
+        if type(value) not in self.EXPECTED_CLASS:
             m = "class mismatch for %s: expected %s, %s has class %s" % (\
-                    self.key_to_string(name), validator.EXPECTED_CLASS,
+                    self.key_to_string(name), self.EXPECTED_CLASS,
                     str(value), value.__class__.__name__)
             raise DataValidationException(m)
-        if hasattr(validator, "_validate"):
-            validator._validate(str(name), value)
+        if hasattr(self, "_validate"):
+            self._validate(str(name), value)
 
 
 

--- a/zschema/leaves.py
+++ b/zschema/leaves.py
@@ -448,14 +448,16 @@ class DateTime(Leaf):
 
     def _validate(self, name, value):
         if isinstance(value, datetime.datetime):
-            return
-
-        # FIXME: ignoretz should be set for TIMESTAMP but not DATETIME?
-        try:
-            dt = dateutil.parser.parse(value, ignoretz=True)
-        except Exception, e:
-            m = "%s: %s is not valid timestamp" % (name, str(value))
-            raise DataValidationException(m)
+            dt = value
+        elif isinstance(value, int):
+            dt = datetime.datetime.utcfromtimestamp(value)
+        else:
+            # FIXME: ignoretz should be set for TIMESTAMP but not DATETIME?
+            try:
+                dt = dateutil.parser.parse(value, ignoretz=True)
+            except Exception, e:
+                m = "%s: %s is not valid timestamp" % (name, str(value))
+                raise DataValidationException(m)
         if dt > self._max_value_dt:
             m = "%s: %s is larger than allowed maximum (%s)" % (name,
                     str(value), str(self._max_value_dt))

--- a/zschema/leaves.py
+++ b/zschema/leaves.py
@@ -296,10 +296,12 @@ class IPAddress(Leaf):
     INVALID = "my string"
     VALID = "141.212.120.0"
 
-    IPV4_REGEX = re.compile('(\d{1,3}\.){3}\d{1,3}')
-
     def _is_ipv4_addr(self, ip):
-        return bool(self.IPV4_REGEX.match(ip))
+        try:
+            socket.inet_pton(socket.AF_INET, ip)
+            return True
+        except socket.error:
+            return False
 
     def _is_ipv6_addr(self, ip):
         try:

--- a/zschema/leaves.py
+++ b/zschema/leaves.py
@@ -293,6 +293,9 @@ class IPAddress(Leaf):
     BQ_TYPE = "STRING"
     EXPECTED_CLASS = [str,unicode]
 
+    INVALID = "my string"
+    VALID = "141.212.120.0"
+
     IPV4_REGEX = re.compile('(\d{1,3}\.){3}\d{1,3}')
 
     def _is_ipv4_addr(self, ip):
@@ -313,7 +316,7 @@ class IPAddress(Leaf):
 
 class IPv4Address(IPAddress):
 
-    INVALID = "my string"
+    INVALID = "2a04:9740:8:c010:e228:6dff:fefe:6e53"
     VALID = "141.212.120.0"
 
     def _validate(self, name, value):
@@ -324,7 +327,7 @@ class IPv4Address(IPAddress):
 
 class IPv6Address(IPAddress):
 
-    INVALID = "my string"
+    INVALID = "141.212.120.0"
     VALID = "2a04:9740:8:c010:e228:6dff:fefe:6e53"
 
     def _validate(self, name, value):

--- a/zschema/leaves.py
+++ b/zschema/leaves.py
@@ -461,7 +461,7 @@ class DateTime(Leaf):
     INVALID = "Wed DNE  35 08:52:01 EDT 2015"
 
     MIN_VALUE = "1753-01-01 00:00:00.000000"
-    MAX_VALUE = "9999-12-31 00:00:00.000000"
+    MAX_VALUE = "9999-12-31 23:59:59.999999"
 
     def __init__(self, *args, **kwargs):
         super(DateTime, self).__init__(*args, **kwargs)

--- a/zschema/leaves.py
+++ b/zschema/leaves.py
@@ -25,7 +25,8 @@ class Leaf(Keyable):
             metadata=None,
             units=None,
             min_value=None,
-            max_value=None):
+            max_value=None,
+            validator=None):
         self.required = required
         self.es_index = es_index
         self.es_analyzer = es_analyzer
@@ -47,6 +48,7 @@ class Leaf(Keyable):
         self.units = units
         self.min_value = min_value
         self.max_value = max_value
+        self.validator = validator
 
     def to_dict(self):
         retv = {
@@ -146,21 +148,22 @@ class Leaf(Keyable):
         print val
 
     def validate(self, name, value):
-        if not self._check_valid_name(name):
+        validator = self.validator or self
+        if not validator._check_valid_name(name):
             raise DataValidationException("Invalid field name: %s" % name)
         if value is None:
-            if self.required:
+            if validator.required:
                 raise DataValidationException("%s is a required field, but "
                                               "recieved None" % name)
             else:
                 return
-        if type(value) not in self.EXPECTED_CLASS:
+        if type(value) not in validator.EXPECTED_CLASS:
             m = "class mismatch for %s: expected %s, %s has class %s" % (\
-                    self.key_to_string(name), self.EXPECTED_CLASS,
+                    self.key_to_string(name), validator.EXPECTED_CLASS,
                     str(value), value.__class__.__name__)
             raise DataValidationException(m)
-        if hasattr(self, "_validate"):
-            self._validate(str(name), value)
+        if hasattr(validator, "_validate"):
+            validator._validate(str(name), value)
 
 
 

--- a/zschema/leaves.py
+++ b/zschema/leaves.py
@@ -26,8 +26,7 @@ class Leaf(Keyable):
             metadata=None,
             units=None,
             min_value=None,
-            max_value=None,
-            validator=None):
+            max_value=None):
         self.required = required
         self.es_index = es_index
         self.es_analyzer = es_analyzer
@@ -49,7 +48,6 @@ class Leaf(Keyable):
         self.units = units
         self.min_value = min_value
         self.max_value = max_value
-        self.validator = validator
 
     def to_dict(self):
         retv = {
@@ -149,9 +147,6 @@ class Leaf(Keyable):
         print val
 
     def validate(self, name, value):
-        if self.validator:
-            self.validator.validate(name, value)
-            return
         if not self._check_valid_name(name):
             raise DataValidationException("Invalid field name: %s" % name)
         if value is None:

--- a/zschema/leaves.py
+++ b/zschema/leaves.py
@@ -155,7 +155,7 @@ class Leaf(Keyable):
         if value is None:
             if self.required:
                 raise DataValidationException("%s is a required field, but "
-                                              "recieved None" % name)
+                                              "received None" % name)
             else:
                 return
         if type(value) not in self.EXPECTED_CLASS:

--- a/zschema/tests.py
+++ b/zschema/tests.py
@@ -776,5 +776,4 @@ class DatetimeTest(unittest.TestCase):
         DateTimeRecord = DateTime()
         DateTimeRecord.validate("fake", datetime.datetime.now())
         DateTimeRecord.validate("fake", "Wed Dec  5 01:23:45 CST 1956")
-        # Note: int values are nominally accepted but not valid
-        # DateTimeRecord.validate("fake", 116048701)
+        DateTimeRecord.validate("fake", 116048701)


### PR DESCRIPTION
This PR makes a few changes to ZSchema in support of validating against our existing schema:

* Support timestamps in seconds-past-epoch format (https://github.com/zmap/zschema/commit/dded7060ac8660cecd04f509cff70e117a8675b3)
* Support IPv6 addresses (https://github.com/zmap/zschema/commit/32c7e99ce4e787e6483980cfeb970074ecb14519)
* Consider dates valid until `9999-12-31 23:59:59.999999` (same as BigQuery) (https://github.com/zmap/zschema/commit/c0eabb57f4ddba50dbd03f3cffba0b0097dd272e)

~~And this adds support for using an alternate type to validate a field in a schema: https://github.com/zmap/zschema/commit/175691f3c52cb5e5f1f9c119cc99f42012ec8f86 , https://github.com/zmap/zschema/commit/7965eb2b33d755ce6b7805c17c1792e15945a8b3 , https://github.com/zmap/zschema/commit/07b24ee45bbd6e8c6ed3cfa186dedb3e0d59beea . @zakird, is your thinking that #40 replaces this functionality?~~