### PR TITLE
Validate null subvalues only by checking whether they’re required

### DIFF
--- a/zschema/compounds.py
+++ b/zschema/compounds.py
@@ -263,9 +263,12 @@ class SubRecord(Keyable):
                 if not self.allow_unknown and subkey not in self.definition:
                     raise DataValidationException("%s: %s is not a valid subkey" %
                                                   (name, subkey))
-                if subkey in self.definition:
+                if subkey in self.definition and subvalue is not None:
                     self.definition[subkey].validate(subkey, subvalue,
                             policy, calculated_policy)
+                if subvalue is None and self.definition[subkey].required:
+                    m = "Subkey %s is None but is marked required" % (subkey)
+                    raise DataValidationException(m)
             except DataValidationException as e:
                 self._handle_validation_exception(calculated_policy, e)
 
@@ -356,8 +359,12 @@ class Record(SubRecord):
             try:
                 if subkey not in self.definition:
                     raise DataValidationException("%s is not a valid subkey of root" % subkey)
-                self.definition[subkey].validate(subkey, subvalue, policy,
-                        self.validation_policy)
+                if subvalue is not None:
+                    self.definition[subkey].validate(subkey, subvalue, policy,
+                            self.validation_policy)
+                if subvalue is None and self.definition[subkey].required:
+                    m = "Subkey %s is None but is marked required" % (subkey)
+                    raise DataValidationException(m)
             except DataValidationException as e:
                 self._handle_validation_exception(calculated_policy, e)
 

--- a/zschema/tests.py
+++ b/zschema/tests.py
@@ -555,9 +555,8 @@ class CompileAndValidationTests(unittest.TestCase):
         }
         try:
             self.host.validate(test)
-            self.fail("heartbleed is null")
         except DataValidationException:
-            pass
+            self.fail("heartbleed is null, but not marked required")
 
     def test_null_port(self):
         test = {
@@ -566,9 +565,8 @@ class CompileAndValidationTests(unittest.TestCase):
         }
         try:
             self.host.validate(test)
-            self.fail("443 is null")
         except DataValidationException:
-            pass
+            self.fail("443 is null, but not marked required")
 
     def test_null_notrequired(self):
         test = {

--- a/zschema/tests.py
+++ b/zschema/tests.py
@@ -696,6 +696,20 @@ class SubRecordTests(unittest.TestCase):
         self.assertEqual("The CA certificate.", OtherType.definition["ca"].doc)
         self.assertEqual("The host certificate.", OtherType.definition["host"].doc)
 
+    def test_null_is_accepted_for_optional_subrecord(self):
+        schema = Record({
+            "domain":String(required=True),
+            "metadata": SubRecord({}, required=False),
+        }, validation_policy="error")
+        document = {
+            "domain": "dzombak.com",
+            "metadata": None,
+        }
+        try:
+            schema.validate(document)
+        except DataValidationException as e:
+            self.fail("Validation failed for a null SubRecord marked as optional")
+
 
 class NestedListOfTests(unittest.TestCase):
     pass


### PR DESCRIPTION
Previously, if a subrecord contained `null` for some field, it would fail validation even if that field wasn't marked required.

With this change, non-required fields are allowed to contain `null`.