### PR TITLE
Fix ListOf exclude (re #51)

### DIFF
--- a/zschema/compounds.py
+++ b/zschema/compounds.py
@@ -25,11 +25,15 @@ class ListOf(Keyable):
 
     @property
     def exclude_bigquery(self):
-        return self.object_.exclude_bigquery
+        # If the child type is excluded, that is the same as excluding this --
+        # it's not clear what it would mean otherwise, from a schema perspective
+        return super(ListOf, self).exclude_bigquery \
+               or self.object_.exclude_bigquery
 
     @property
     def exclude_elasticsearch(self):
-        return self.object_.exclude_elasticsearch
+        return super(ListOf, self).exclude_elasticsearch \
+               or self.object_.exclude_elasticsearch
 
     def print_indent_string(self, name, indent):
         tabs = "\t" * indent if indent else ""

--- a/zschema/tests.py
+++ b/zschema/tests.py
@@ -839,3 +839,21 @@ class ValidationPolicies(unittest.TestCase):
             }
         }
         self.assertRaises(DataValidationException, lambda: schema.validate(doc))
+
+class ExcludeTests(unittest.TestCase):
+    def test_ListOf_exclude(self):
+        a = ListOf(String())
+        self.assertFalse(a.exclude_bigquery)
+        self.assertFalse(a.exclude_elasticsearch)
+
+        b = ListOf(String(exclude=["bigquery"]))
+        self.assertTrue(b.exclude_bigquery)
+        self.assertFalse(b.exclude_elasticsearch)
+
+        c = ListOf(String(), exclude=["elasticsearch"])
+        self.assertFalse(c.exclude_bigquery)
+        self.assertTrue(c.exclude_elasticsearch)
+
+        d = ListOf(String(exclude=["bigquery"]), exclude=["elasticsearch"])
+        self.assertTrue(d.exclude_bigquery)
+        self.assertTrue(d.exclude_elasticsearch)

--- a/zschema/tests.py
+++ b/zschema/tests.py
@@ -857,3 +857,5 @@ class ExcludeTests(unittest.TestCase):
         d = ListOf(String(exclude=["bigquery"]), exclude=["elasticsearch"])
         self.assertTrue(d.exclude_bigquery)
         self.assertTrue(d.exclude_elasticsearch)
+
+    # TODO: test the rest of the types


### PR DESCRIPTION
Previously, to exclude a `ListOf(x)` value from BigQuery, you added `exclude=["bigquery"]` to `x`; adding it to the `ListOf()` had no effect.

This is how all of the existing types expected it to work until recently, when `certificate_policies` had the `exclude` moved from the `CertificatePoliciesData` child element to the `certificate_policies` list itself.

This patch allows both the old version and the more intuitive version to work.

Fixes #51.