### PR TITLE
Add 'dynamic = strict' in es mappings generation

### DIFF
--- a/zschema/compounds.py
+++ b/zschema/compounds.py
@@ -390,9 +390,13 @@ class NestedListOf(ListOf):
 class Record(SubRecord):
 
     VALIDATION_POLICY = "error"
+    ES_DYNAMIC_POLICY = None
 
     def to_es(self, name):
-        return {name:SubRecord.to_es(self)}
+        subrecord = SubRecord.to_es(self)
+        if self.es_dynamic_policy != None:
+            subrecord["dynamic"] = self.es_dynamic_policy
+        return {name:subrecord}
 
     def docs_es(self, name, parent_category=None):
         category = self.category or parent_category

--- a/zschema/keys.py
+++ b/zschema/keys.py
@@ -287,7 +287,8 @@ class Keyable(object):
 
     def __init__(self, required=_NO_ARG, desc=_NO_ARG, doc=_NO_ARG, category=_NO_ARG,
             exclude=_NO_ARG, deprecated=_NO_ARG, ignore=_NO_ARG,
-            examples=_NO_ARG, metadata=_NO_ARG, validation_policy=_NO_ARG, pr_index=_NO_ARG, pr_ignore=_NO_ARG):
+            examples=_NO_ARG, metadata=_NO_ARG, validation_policy=_NO_ARG, pr_index=_NO_ARG,
+            pr_ignore=_NO_ARG, es_dynamic_policy=_NO_ARG):
         global _keyable_counter
         self.set("required", required)
         self.set("desc", desc)
@@ -303,6 +304,7 @@ class Keyable(object):
         self.set("implicit_index", _keyable_counter)
         _keyable_counter += 1
         self.set("pr_ignore", pr_ignore)
+        self.set("es_dynamic_policy", es_dynamic_policy)
 
         if self.DEPRECATED_TYPE:
             e = "WARN: %s is deprecated and will be removed in a "\

--- a/zschema/tests.py
+++ b/zschema/tests.py
@@ -617,6 +617,17 @@ class CompileAndValidationTests(unittest.TestCase):
         })
         ipv4_host_ssh.validate(json_fixture('ipv4-ssh-record'))
 
+    def test_es_dynamic_record(self):
+        ipv4_host_with_dynamic_strict = Record()
+        es = ipv4_host_with_dynamic_strict.to_es("strict-record")
+        self.assertFalse("dynamic" in es["strict-record"])
+
+        ipv4_host_with_dynamic_strict = Record(
+            es_dynamic_policy="strict"
+        )
+        es = ipv4_host_with_dynamic_strict.to_es("strict-record")
+        self.assertEqual("strict", es["strict-record"]["dynamic"])
+
     def test_subrecord_types(self):
         SSH = SubRecordType({
             "banner":SubRecord({


### PR DESCRIPTION
This will disable dynamic field mapping so document's are
rejected if they have a field that doesn't have a mapping
defined.