### PR TITLE
SubRecordType()() objects behave like objects

### DIFF
--- a/zschema/compounds.py
+++ b/zschema/compounds.py
@@ -348,7 +348,7 @@ class SubRecord(Keyable):
 
 class _SubRecordDefaulted(SubRecord):
 
-    _INIT_DEFAULTS = dict()
+    _INIT_DEFAULTS = None
 
     @classmethod
     def _get_copy_default(cls, k):
@@ -375,7 +375,6 @@ class _SubRecordDefaulted(SubRecord):
             **kwargs
         )
 
-
     @classmethod
     def _set_default_at_init(cls, k, v):
         cls._INIT_DEFAULTS[k] = v
@@ -392,8 +391,11 @@ def SubRecordType(definition,
         category=_NO_ARG,
         validation_policy=_NO_ARG,
         pr_ignore=_NO_ARG):
+    #import pdb; pdb.set_trace()
     name = type_name if type_name else "SubRecordType"
-    t = type(name, (_SubRecordDefaulted,), {})
+    t = type(name, (_SubRecordDefaulted,), {
+        "_INIT_DEFAULTS": dict(),
+    })
     t._set_default_at_init("definition", definition)
     t._set_default_at_init("type_name", type_name)
     t._set_default_at_init("required", required)

--- a/zschema/compounds.py
+++ b/zschema/compounds.py
@@ -150,7 +150,7 @@ class SubRecord(Keyable):
 
     def __init__(self, definition=_NO_ARG, extends=_NO_ARG,
             allow_unknown=_NO_ARG, type_name=_NO_ARG, *args, **kwargs):
-        super(SubRecord, self).__init__(**kwargs)
+        super(SubRecord, self).__init__(*args, **kwargs)
         self.set("definition", definition)
         self.set("allow_unknown", allow_unknown)
         self.set("type_name", type_name)

--- a/zschema/compounds.py
+++ b/zschema/compounds.py
@@ -150,7 +150,7 @@ class SubRecord(Keyable):
 
     def __init__(self, definition=_NO_ARG, extends=_NO_ARG,
             allow_unknown=_NO_ARG, type_name=_NO_ARG, *args, **kwargs):
-        super(SubRecord, self).__init__(*args, **kwargs)
+        super(SubRecord, self).__init__(**kwargs)
         self.set("definition", definition)
         self.set("allow_unknown", allow_unknown)
         self.set("type_name", type_name)
@@ -346,6 +346,42 @@ class SubRecord(Keyable):
                 self._handle_validation_exception(calculated_policy, e)
 
 
+class _SubRecordDefaulted(SubRecord):
+
+    _INIT_DEFAULTS = dict()
+
+    @classmethod
+    def _get_copy_default(cls, k):
+        v = cls._INIT_DEFAULTS.get(k, _NO_ARG)
+        return copy.deepcopy(v)
+
+    def __init__(self, definition=_NO_ARG, extends=_NO_ARG,
+                 allow_unknown=_NO_ARG, type_name=_NO_ARG, *args, **kwargs):
+        definition = definition or self._get_copy_default('definition')
+        allow_unknown = allow_unknown or self._get_copy_default(
+                'allow_unknown')
+        type_name = type_name or self._get_copy_default('type_name')
+        for k, v in self._INIT_DEFAULTS.items():
+            if k in {"definition", "allow_unknown", "type_name"}:
+                # These keys are managed by the constructor
+                continue
+            self.set(k, copy.deepcopy(v))
+        super(_SubRecordDefaulted, self).__init__(
+            definition=definition,
+            extends=extends,
+            allow_unknown=allow_unknown,
+            type_name=type_name,
+            *args,
+            **kwargs
+        )
+
+
+    @classmethod
+    def _set_default_at_init(cls, k, v):
+        cls._INIT_DEFAULTS[k] = v
+        cls.set_default(k, v)
+
+
 def SubRecordType(definition,
         required=_NO_ARG,
         type_name=_NO_ARG,
@@ -356,17 +392,18 @@ def SubRecordType(definition,
         category=_NO_ARG,
         validation_policy=_NO_ARG,
         pr_ignore=_NO_ARG):
-    t = type("SubRecord", (SubRecord,), {})
-    t.set_default("definition", definition)
-    t.set_default("type_name", type_name)
-    t.set_default("required", required)
-    t.set_default("doc", doc)
-    t.set_default("desc", desc)
-    t.set_default("allow_unknown", allow_unknown)
-    t.set_default("exclude", exclude)
-    t.set_default("category", category)
-    t.set_default("validation_policy", validation_policy)
-    t.set_default("pr_ignore", pr_ignore)
+    name = type_name if type_name else "SubRecordType"
+    t = type(name, (_SubRecordDefaulted,), {})
+    t._set_default_at_init("definition", definition)
+    t._set_default_at_init("type_name", type_name)
+    t._set_default_at_init("required", required)
+    t._set_default_at_init("doc", doc)
+    t._set_default_at_init("desc", desc)
+    t._set_default_at_init("allow_unknown", allow_unknown)
+    t._set_default_at_init("exclude", exclude)
+    t._set_default_at_init("category", category)
+    t._set_default_at_init("validation_policy", validation_policy)
+    t._set_default_at_init("pr_ignore", pr_ignore)
     return t
 
 

--- a/zschema/tests.py
+++ b/zschema/tests.py
@@ -1151,11 +1151,10 @@ class TestSubRecordType(unittest.TestCase):
     def test_multiple_subrecord_types(self):
         A = SubRecordType({
             "first": String(),
-        })
-
+        }, type_name="A")
         B = SubRecordType({
             "second": Boolean(),
-        })
+        }, type_name="B")
 
         a = A()
         self.assertIn("first", a.definition)


### PR DESCRIPTION
Every object created by a type returned by SubRecordType effectively
stored all of it's attributes as class attributes, which meant that if
you did the following:

```
MyType = SubRecordType()
a = MyType()
b = MyType()
```

...then changes to `a` would be reflected on `b`, which broke isolation
of types in schemas.

This reset properties defined in the call to SubRecordType() at object
initialization and applies them to the instances, which should prevent
weird interactions between objects.